### PR TITLE
Python 3 compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 
 The change history, in order from newest to oldest.
 
+1.11
+====
+
++ Python 3 compatibility.
++ NSS Group support. Add group ``_nss`` to your default user to get NSS groups
+  for users (Python 3 required).
+
 1.10
 ====
 

--- a/do_auth.py
+++ b/do_auth.py
@@ -243,7 +243,7 @@ __maintainer__ = 'Dan Schmidt, Jathan McCollum'
 __email__ = 'daniel.schmidt@wyo.gov'
 __copyright__ = 'Dan Schmidt'
 __license__ = 'GPL-3.0'
-__version__ = '1.10'
+__version__ = '1.11'
 
 try:
     import configparser


### PR DESCRIPTION
Tested against:
2.4.3 (for itertools.product compatibility), 2.6.6, and 3.3.2

Python3 adds some additional functionality in os (getgrouplist) which may be useful in environments where people want to pull NSS group lists.
